### PR TITLE
Add VSCode devcontainer configuration.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/rust/.devcontainer/base.Dockerfile
+
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
+
+# Install additional required packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends libusb-1.0-0-dev libfuse-dev rust-gdb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/rust
+{
+  "name": "Rust",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+      // Use bullseye when on local on arm64/Apple Silicon.
+      "VARIANT": "buster"
+    }
+  },
+
+  // For SELinux enabled systems (ie. Fedora) we need to mount the volume with the :Z option
+  // See https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
+  "workspaceMount": "",
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"
+  ],
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "lldb.executable": "/usr/bin/lldb",
+    // VS Code don't watch files under ./target
+    "files.watcherExclude": {
+      "**/target/**": true
+    },
+    "rust-analyzer.checkOnSave.command": "clippy"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+	"vadimcn.vscode-lldb",
+	"mutantdino.resourcemonitor",
+	"matklad.rust-analyzer",
+	"tamasfe.even-better-toml",
+	"serayuzgur.crates",
+	"rust-lang.rust",
+  "webfreak.debug"
+],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "rustc --version",
+
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,6 @@
 	"matklad.rust-analyzer",
 	"tamasfe.even-better-toml",
 	"serayuzgur.crates",
-	"rust-lang.rust",
   "webfreak.debug"
 ],
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,10 @@
     "--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"
   ],
 
+  "containerEnv": {
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  },
+
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "lldb.executable": "/usr/bin/lldb",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,12 @@
             "name": "it9910hd_fusefs",
             "request": "launch",
             "type": "gdb",
-            "target": "${workspaceRoot}/target/debug/it9910hd_fusefs",
-            "cwd": "${workspaceRoot}",
+            "target": "${workspaceFolder}/target/debug/it9910hd_fusefs",
+            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1"
             },
+            "arguments": "./video",
             "preLaunchTask": "build_it9910hd_fusefs"
         },
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,9 +4,14 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "build_it9910hd_fusefs",
+            "label": "build_it9910hd_fusefs",
             "type": "shell",
-            "command": "cargo build"
-        },
+            "command": "cargo build",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
     ]
 }


### PR DESCRIPTION
This PR adds [VSCode devcontainer](https://code.visualstudio.com/docs/remote/containers) configuration files, to hopefully make it easier for people to get a development environment out of the box. The configuration is configured with full compatibility with SELinux enabled systems (ie. Fedora).

It also has a slightly tweaked build task that's set as the default build task (so you can trigger it with `ctrl+shift+b`). 

The devcontainer configuration should come with all the necessary packages (and VSCode extensions), including `libusb-1.0-0-dev`, `libfuse-dev`, and `rust-gdb`. Please let me know if I missed anything :).